### PR TITLE
fix: use dark theme on wash pages

### DIFF
--- a/src/app/[lng]/layout.tsx
+++ b/src/app/[lng]/layout.tsx
@@ -14,6 +14,7 @@ import type { Viewport } from 'next/types';
 import type { ReactNode } from 'react';
 import { defaultNS, fallbackLng, namespaces } from 'src/i18n';
 import { SettingsStoreProvider } from 'src/stores/settings';
+import { getWashThemeMode } from 'src/wash/utils/getWashThemeMode';
 import type { ActiveThemeResult } from '../lib/getActiveTheme';
 import { getActiveTheme } from '../lib/getActiveTheme';
 import { description, siteName, title } from '../lib/metadata';
@@ -122,6 +123,8 @@ export default async function RootLayout({
     isPartnerTheme ||
     cookiesHandler.get('welcomeScreenClosed')?.value === 'true';
 
+  const washThemeMode = getWashThemeMode(cookiesHandler);
+
   return (
     <html
       lang={lng || fallbackLng}
@@ -174,7 +177,7 @@ export default async function RootLayout({
                 <ThemeProvider
                   themes={themes}
                   activeTheme={activeTheme}
-                  themeMode={themeMode}
+                  themeMode={washThemeMode ? 'dark' : themeMode}
                 >
                   <SettingsStoreProvider
                     welcomeScreenClosed={welcomeScreenClosed}

--- a/src/app/[lng]/wash/layout.tsx
+++ b/src/app/[lng]/wash/layout.tsx
@@ -1,9 +1,12 @@
 import type { Metadata } from 'next';
 import type { PropsWithChildren } from 'react';
-import { Layout } from 'src/Layout';
+import { Layout } from '../../../Layout';
 
-export const metadata: Metadata = {};
-
+export const metadata: Metadata = {
+  other: {
+    'partner-theme': 'dark',
+  },
+};
 export default async function WastLayout({ children }: PropsWithChildren) {
   return (
     <Layout>

--- a/src/app/lib/getActiveTheme.ts
+++ b/src/app/lib/getActiveTheme.ts
@@ -45,7 +45,7 @@ export async function getActiveTheme(
 
   return {
     themes: partnerThemes.data,
-    activeTheme: washThemeMode ? 'dark' : activeTheme,
+    activeTheme: washThemeMode || activeTheme,
     themeMode:
       washThemeMode || (cookiesHandler.get('themeMode')?.value as ThemeMode),
     isPartnerTheme: Boolean(pathPartnerTheme),

--- a/src/app/lib/getActiveTheme.ts
+++ b/src/app/lib/getActiveTheme.ts
@@ -1,6 +1,7 @@
-import type { PartnerThemesData, StrapiResponseData } from '@/types/strapi';
-import { type ThemeMode } from '@/types/theme';
 import type { cookies } from 'next/headers';
+import type { PartnerThemesData, StrapiResponseData } from '../../types/strapi';
+import type { ThemeMode } from '../../types/theme';
+import { getWashThemeMode } from '../../wash/utils/getWashThemeMode';
 import { getPartnerThemes } from './getPartnerThemes';
 
 export type ActiveThemeResult = {
@@ -40,10 +41,13 @@ export async function getActiveTheme(
   const activeTheme =
     pathPartnerTheme || (cookieThemeIsPartnerTheme ? 'default' : cookieTheme);
 
+  const washThemeMode = getWashThemeMode(cookiesHandler);
+
   return {
     themes: partnerThemes.data,
-    activeTheme,
-    themeMode: cookiesHandler.get('themeMode')?.value as ThemeMode,
+    activeTheme: washThemeMode ? 'dark' : activeTheme,
+    themeMode:
+      washThemeMode || (cookiesHandler.get('themeMode')?.value as ThemeMode),
     isPartnerTheme: Boolean(pathPartnerTheme),
   };
 }

--- a/src/providers/ThemeProvider/utils.ts
+++ b/src/providers/ThemeProvider/utils.ts
@@ -63,6 +63,9 @@ export function getEffectiveThemeMode(
   themeMode?: ThemeMode,
   resolvedTheme?: string,
 ): ThemeMode {
+  if (themeMode) {
+    return themeMode;
+  }
   if (resolvedTheme === 'system') {
     return themeMode || 'system';
   }

--- a/src/wash/utils/getWashThemeMode.ts
+++ b/src/wash/utils/getWashThemeMode.ts
@@ -1,0 +1,12 @@
+import type { cookies } from 'next/headers';
+
+export const getWashThemeMode = (
+  cookiesHandler: ReturnType<typeof cookies>,
+) => {
+  const pathname = cookiesHandler.get('pathname')?.value || '/';
+  const segments = pathname.split('/').slice(0, 3);
+  if (segments.includes('wash')) {
+    return 'dark';
+  }
+  return undefined;
+};

--- a/src/wash/utils/getWashThemeMode.ts
+++ b/src/wash/utils/getWashThemeMode.ts
@@ -5,7 +5,7 @@ export const getWashThemeMode = (
 ) => {
   const pathname = cookiesHandler.get('pathname')?.value || '/';
   const segments = pathname.split('/').slice(0, 3);
-  if (segments.includes('wash')) {
+  if (segments.includes('wash') && !segments.includes('learn')) {
     return 'dark';
   }
   return undefined;


### PR DESCRIPTION
Adjusting the default themeMode of wash pages as "dark" to adjust colors in components such as Logo, Menu, ..

![image](https://github.com/user-attachments/assets/7557f53d-368e-49d0-9dfe-6f4f3d203f81)
