### PR TITLE
chore: add wash trade entry to menu

### DIFF
--- a/src/components/Menus/MainMenu/useMainMenuContent.tsx
+++ b/src/components/Menus/MainMenu/useMainMenuContent.tsx
@@ -11,6 +11,7 @@ import {
   JUMPER_LEARN_PATH,
   JUMPER_LOYALTY_PATH,
   JUMPER_SCAN_PATH,
+  JUMPER_WASH_PATH,
   X_URL,
 } from '@/const/urls';
 import { useUserTracking } from '@/hooks/userTracking/useUserTracking';
@@ -18,6 +19,7 @@ import { useMenuStore } from '@/stores/menu';
 import { useThemeStore } from '@/stores/theme';
 import { getContrastAlphaColor } from '@/utils/colors';
 import AccountCircleIcon from '@mui/icons-material/AccountCircle';
+import BubbleChartIcon from '@mui/icons-material/BubbleChart';
 import DeveloperModeIcon from '@mui/icons-material/DeveloperMode';
 import LanguageIcon from '@mui/icons-material/Language';
 import SchoolIcon from '@mui/icons-material/School';
@@ -139,6 +141,22 @@ export const useMainMenuContent = () => {
           label: `open_submenu_${MenuKeysEnum.Devs.toLowerCase()}`,
           data: { [TrackingEventParameter.Menu]: MenuKeysEnum.Devs },
         });
+      },
+    },
+    {
+      label: 'Solana Washtrade',
+      prefixIcon: <BubbleChartIcon />,
+      showMoreIcon: false,
+      link: { url: JUMPER_WASH_PATH },
+      onClick: () => {
+        trackEvent({
+          category: TrackingCategory.Menu,
+          label: 'click-wash-trade-link',
+          action: 'action_click_wash_trade_link',
+          data: { [TrackingEventParameter.Menu]: 'wash' },
+        });
+        closeAllMenus();
+        router.push(JUMPER_WASH_PATH);
       },
     },
     {

--- a/src/const/urls.ts
+++ b/src/const/urls.ts
@@ -12,6 +12,7 @@ export const JUMPER_LEARN_PATH = '/learn';
 export const JUMPER_LOYALTY_PATH = '/profile';
 export const JUMPER_SCAN_PATH = '/scan';
 export const JUMPER_BRIDGE_PATH = '/bridge';
+export const JUMPER_WASH_PATH = '/wash';
 export const JUMPER_TX_PATH = '/tx';
 export const JUMPER_WALLET_PATH = '/wallet';
 export const JUMPER_FEST_PATH = '/superfest';


### PR DESCRIPTION
Let´s give users a chance to navigate to our wash pages!
But maybe we can even find a better icon?

![image](https://github.com/user-attachments/assets/5955f6f3-8681-4335-a057-fb3c4b5cd649)
