### PR TITLE
fix: position vertical tabs + wallet connection check

### DIFF
--- a/src/components/Menus/VerticalMenu/VerticalTabs.tsx
+++ b/src/components/Menus/VerticalMenu/VerticalTabs.tsx
@@ -2,8 +2,9 @@
 import { useActiveTabStore } from '@/stores/activeTab';
 import { Tooltip, useMediaQuery } from '@mui/material';
 import type { Theme } from '@mui/material/styles';
+import { useGetNFT } from '../../../wash/hooks/useGetNFT';
 import { useVerticalTabs } from './useVerticalTabs';
-import { VerticalTabsContainer, VerticalTab } from './VerticalTabs.style';
+import { VerticalTab, VerticalTabsContainer } from './VerticalTabs.style';
 
 export const VerticalTabs = () => {
   const { activeTab, setActiveTab } = useActiveTabStore();
@@ -12,10 +13,12 @@ export const VerticalTabs = () => {
     setActiveTab(newValue);
   };
   const verticalTabs = useVerticalTabs();
+  const data = useGetNFT();
 
   return (
     <VerticalTabsContainer
       value={!isDesktop ? false : activeTab}
+      sx={{ ...(data.hasNFT && { marginTop: '140px' }) }}
       orientation="vertical"
       onChange={handleChange}
       aria-label="vertical-tabs"

--- a/src/components/Menus/VerticalMenu/VerticalTabs.tsx
+++ b/src/components/Menus/VerticalMenu/VerticalTabs.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useActiveTabStore } from '@/stores/activeTab';
+import { useAccount } from '@lifi/wallet-management';
 import { Tooltip, useMediaQuery } from '@mui/material';
 import type { Theme } from '@mui/material/styles';
 import { useGetNFT } from '../../../wash/hooks/useGetNFT';
@@ -14,11 +15,12 @@ export const VerticalTabs = () => {
   };
   const verticalTabs = useVerticalTabs();
   const data = useGetNFT();
+  const { account } = useAccount();
 
   return (
     <VerticalTabsContainer
       value={!isDesktop ? false : activeTab}
-      sx={{ ...(data.hasNFT && { marginTop: '140px' }) }}
+      sx={{ ...(data.hasNFT && account?.address && { marginTop: '140px' }) }}
       orientation="vertical"
       onChange={handleChange}
       aria-label="vertical-tabs"

--- a/src/wash/common/WashProgressAlert/WashProgressAlert.tsx
+++ b/src/wash/common/WashProgressAlert/WashProgressAlert.tsx
@@ -1,3 +1,4 @@
+import { useAccount } from '@lifi/wallet-management';
 import { useRouter } from 'next/navigation';
 import {
   WashProgressAlertButton,
@@ -18,12 +19,14 @@ import { colors } from '../../utils/theme';
 export const WashProgressAlert = () => {
   const data = useGetNFT();
   const router = useRouter();
+  const { account } = useAccount();
 
   const handleWashCta = () => {
     router.push(JUMPER_WASH_PATH);
   };
 
   return (
+    account?.address &&
     data.hasNFT && (
       <WashProgressAlertContainer className="alert">
         <WashProgressAlertTitle>Wash trade</WashProgressAlertTitle>


### PR DESCRIPTION
1.) Align "Vertical Tabs" to be on the same vertical position as the Widget, instead of the wash-trade-progress cta box
![image](https://github.com/user-attachments/assets/9e7bd390-2a2c-4f93-92f3-f28cfddc797a)


2.) Only show the wash-trade-progress cta box if the wallet is connected. Hide after wallet is being disconnected